### PR TITLE
only assign svgimage source if new value is not null

### DIFF
--- a/Source/SVGImage/SVG/SVGImage.cs
+++ b/Source/SVGImage/SVG/SVGImage.cs
@@ -728,11 +728,8 @@ namespace SVGImage.SVG
 
         static void OnSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (e.NewValue != null)
-            {
-                StreamResourceInfo resource = Application.GetResourceStream(new Uri(e.NewValue.ToString(), UriKind.Relative));
-                ((SVGImage)d).SetImage(resource.Stream);
-            }
+            StreamResourceInfo resource = e.NewValue != null ? Application.GetResourceStream(new Uri(e.NewValue.ToString(), UriKind.Relative)) : null;
+            ((SVGImage)d).SetImage(resource != null ? resource.Stream : null);
         }
 
         static void OnFileSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/Source/SVGImage/SVG/SVGImage.cs
+++ b/Source/SVGImage/SVG/SVGImage.cs
@@ -728,8 +728,11 @@ namespace SVGImage.SVG
 
         static void OnSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            StreamResourceInfo resource = Application.GetResourceStream(new Uri(e.NewValue.ToString(), UriKind.Relative));
-            ((SVGImage)d).SetImage(resource.Stream);
+            if (e.NewValue != null)
+            {
+                StreamResourceInfo resource = Application.GetResourceStream(new Uri(e.NewValue.ToString(), UriKind.Relative));
+                ((SVGImage)d).SetImage(resource.Stream);
+            }
         }
 
         static void OnFileSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
(this might be the case for instance when changing/overriding  the used resourcedictionary)

just a small change, I noticed this was the only error I was getting when I was trying to switch application wide styles, because I suppose it would leave the svgimage without a value when removing the currently used resource dictionary before applying a new one - hence ignore empty values in OnSourceChanged...

Probably could make sense to do this check for UriSource too, but I just tested it for Source ;)
I got a working example here https://github.com/DrCopyPaste/RecNForget/tree/feature/embedForkSvgImage