### PR TITLE
changed code to not convert double to int

### DIFF
--- a/Source/SVGImage/SVG/SVGRender.cs
+++ b/Source/SVGImage/SVG/SVGRender.cs
@@ -132,7 +132,7 @@ namespace SVGImage.SVG
                     item.Pen.DashCap = PenLineCap.Flat;
                     DashStyle ds = new DashStyle();
                     double scale = 1 / stroke.Width;
-                    foreach (int dash in stroke.StrokeArray) ds.Dashes.Add(dash * scale);
+                    foreach (var dash in stroke.StrokeArray) ds.Dashes.Add(dash * scale);
                     item.Pen.DashStyle = ds;
                 }
                 switch (stroke.LineCap)


### PR DESCRIPTION
Found and fixed issue where the stroke-dasharray was not being displayed. This was due to a variable of type double being converted to int. The fix was to simply keep persist the double data type. Below are before and after examples.

**Before Fix**
![image](https://user-images.githubusercontent.com/99045672/152842037-25cee1d8-fb05-435b-b2d0-0035d6a8de1c.png)

**After Fix**
![image](https://user-images.githubusercontent.com/99045672/152842230-510dbca6-bdca-4f27-9054-cd0bd2b65285.png)
