### PR TITLE
Allow setting FileSource to null.

### DIFF
--- a/Source/SVGImage/SVG/SVGImage.cs
+++ b/Source/SVGImage/SVG/SVGImage.cs
@@ -734,7 +734,14 @@ namespace SVGImage.SVG
 
         static void OnFileSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            ((SVGImage)d).SetImage(new FileStream(e.NewValue.ToString(), FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+            if (e.NewValue != null)
+            {
+                ((SVGImage)d).SetImage(new FileStream(e.NewValue.ToString(), FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+            }
+            else
+            {
+                ((SVGImage)d).SetImage((Drawing)null);
+            }
         }
 
         static void OnImageSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
This happens automatically in our project when the SVGImage control is discarded (due e.g. to content changes, and we cannot get around it), but since the property is a string, it would be nice to accept null anyway, and at least not crash :)

I set the image to null when the path is null, which seems to be the right way to reset the image.