### PR TITLE
Allow setting UriSource to null.

### DIFF
--- a/Source/SVGImage/SVG/SVGImage.cs
+++ b/Source/SVGImage/SVG/SVGImage.cs
@@ -716,7 +716,15 @@ namespace SVGImage.SVG
             }
 
             var sourceUri = (Uri)args.NewValue;
-            svgImage.SetImage(sourceUri);
+            if (sourceUri != null)
+            {
+                svgImage.SetImage(sourceUri);    
+            }
+            else
+            {
+                svgImage.SetImage((Drawing)null);
+            }
+            
         }
 
         static void OnSizeTypeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
Just like with the previous pull request: Without this change, discarding the SVGImage results in a crash due to UriSource being set to null from bindings.