### PR TITLE
Set Override Colors independently for Fill and Stroke

### DIFF
--- a/Docs/articles/intro.md
+++ b/Docs/articles/intro.md
@@ -26,3 +26,9 @@ The control only has a couple of properties, `SizeType` and `ImageSource`.
 For `None` and `ContentToSizeNoStretch`, the Horizontal/VerticalContentAlignment properties can be used to position the image within the control.
 
 * `ImageSource` - This property is the same as `SetImage(drawing)`, and is exposed to allow for the source to be set through binding.
+
+The colors of an `SVGImage` can be overridden at run-time through some additional properties of the `SVGImage`:
+
+* `OverrideFillColor` - This property overrides all fill colors of an SVG image
+* `OverrideStrokeColor` - Overrides all stroke colors of an SVG image
+* `OverrideColor` - Overrides all colors of an SVG image. `OverrideFillColor` and `OverrideStrokeColor` take precedence over the `OverrideColor` property.

--- a/Samples/Example/MainWindow.xaml
+++ b/Samples/Example/MainWindow.xaml
@@ -103,7 +103,7 @@
                 <svg1:SVGImage Source="/Example;component/Images/example radgrad01.svg" RenderTransformOrigin="0.848,0.125" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Margin="3" />
                 <svg1:SVGImage Source="/Example;component/Images/tiger.svg" RenderTransformOrigin="0.5,0.5" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Margin="3" />
                 <svg1:SVGImage Source="/Example;component/Images/1.svg" RenderTransformOrigin="0.5,0.5" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Margin="3" />
-                <svg1:SVGImage Source="/Example;component/Images/2.svg" RenderTransformOrigin="0.5,0.5" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Margin="3" />
+                <svg1:SVGImage Source="/Example;component/Images/2.svg" RenderTransformOrigin="0.5,0.5" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Margin="3" OverrideFillColor="DarkGreen" OverrideStrokeColor="DarkSalmon" x:Name="OverrideSeparateColorTest" MouseDoubleClick="SVGImage_MouseDoubleClickSeparateOverride" />
                 <svg1:SVGImage Source="/Example;component/Images/3.svg" RenderTransformOrigin="0.5,0.5" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Margin="3" />
                 <svg1:SVGImage Source="/Example;component/Images/4.svg" RenderTransformOrigin="0.5,0.5" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Margin="3" />
                 <svg1:SVGImage Source="/Example;component/Images/5.svg" RenderTransformOrigin="0.5,0.5" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Margin="3" />

--- a/Samples/Example/MainWindow.xaml.cs
+++ b/Samples/Example/MainWindow.xaml.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.IO.Compression;
 using System.Collections.Generic;
-
+using System.Drawing;
 using System.Windows;
 
 namespace Example
@@ -148,6 +148,25 @@ namespace Example
                 rnd == 0 ? System.Windows.Media.Colors.White :
                 rnd == 1 ? System.Windows.Media.Colors.Magenta :
                 System.Windows.Media.Colors.Black;
+        }
+
+        private void SVGImage_MouseDoubleClickSeparateOverride(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            System.Windows.Media.Color[] colors =
+            {
+                System.Windows.Media.Colors.White,
+                System.Windows.Media.Colors.Magenta,
+                System.Windows.Media.Colors.DarkGreen,
+                System.Windows.Media.Colors.DarkSalmon,
+                System.Windows.Media.Colors.DarkBlue,
+                System.Windows.Media.Colors.Black,
+            };
+            var ran = new Random();
+            var rndFill = ran.Next(0, colors.Length);
+            OverrideSeparateColorTest.OverrideFillColor = colors[rndFill];
+
+            var rndStroke = ran.Next(0, colors.Length);
+            OverrideSeparateColorTest.OverrideStrokeColor = colors[rndStroke];
         }
     }
 }

--- a/Source/SVGImage/SVG/SVGImage.cs
+++ b/Source/SVGImage/SVG/SVGImage.cs
@@ -97,6 +97,14 @@ namespace SVGImage.SVG
             DependencyProperty.Register("OverrideColor", typeof(Color?), typeof(SVGImage),
                 new FrameworkPropertyMetadata(default, FrameworkPropertyMetadataOptions.AffectsRender, OverrideColorPropertyChanged));
 
+        public static readonly DependencyProperty OverrideFillColorProperty =
+            DependencyProperty.Register("OverrideFillColor", typeof(Color?), typeof(SVGImage),
+                new FrameworkPropertyMetadata(default, FrameworkPropertyMetadataOptions.AffectsRender, OverrideFillColorPropertyChanged));
+
+        public static readonly DependencyProperty OverrideStrokeColorProperty =
+            DependencyProperty.Register("OverrideStrokeColor", typeof(Color?), typeof(SVGImage),
+                new FrameworkPropertyMetadata(default, FrameworkPropertyMetadataOptions.AffectsRender, OverrideStrokeColorPropertyChanged));
+
         public static readonly DependencyProperty CustomBrushesProperty = DependencyProperty.Register(nameof(CustomBrushes),
                 typeof(Dictionary<string, Brush>), typeof(SVGImage), new FrameworkPropertyMetadata(default,
                     FrameworkPropertyMetadataOptions.AffectsRender, CustomBrushesPropertyChanged));
@@ -167,6 +175,18 @@ namespace SVGImage.SVG
             set { SetValue(OverrideColorProperty, value); }
         }
 
+        public Color? OverrideFillColor
+        {
+            get { return (Color?)GetValue(OverrideFillColorProperty); }
+            set { SetValue(OverrideFillColorProperty, value); }
+        }
+
+        public Color? OverrideStrokeColor
+        {
+            get { return (Color?)GetValue(OverrideStrokeColorProperty); }
+            set { SetValue(OverrideStrokeColorProperty, value); }
+        }
+
         public double? OverrideStrokeWidth
         {
             get { return (double?)GetValue(OverrideStrokeWidthProperty); }
@@ -234,6 +254,8 @@ namespace SVGImage.SVG
                 _render = new SVGRender();
                 _render.ExternalFileLoader  = this.ExternalFileLoader;
                 _render.OverrideColor       = OverrideColor;
+                _render.OverrideFillColor   = OverrideFillColor;
+                _render.OverrideStrokeColor = OverrideStrokeColor;
                 _render.CustomBrushes       = CustomBrushes;
                 _render.OverrideStrokeWidth = OverrideStrokeWidth;
                 _render.UseAnimations       = this.UseAnimations;
@@ -256,6 +278,8 @@ namespace SVGImage.SVG
                 _render.ExternalFileLoader  = this.ExternalFileLoader;
                 _render.UseAnimations       = false;
                 _render.OverrideColor       = OverrideColor;
+                _render.OverrideFillColor   = OverrideFillColor;
+                _render.OverrideStrokeColor = OverrideStrokeColor;
                 _render.CustomBrushes       = CustomBrushes;
                 _render.OverrideStrokeWidth = OverrideStrokeWidth;
 
@@ -276,6 +300,8 @@ namespace SVGImage.SVG
                 _render = new SVGRender();
                 _render.ExternalFileLoader  = this.ExternalFileLoader;
                 _render.OverrideColor       = OverrideColor;
+                _render.OverrideFillColor   = OverrideFillColor;
+                _render.OverrideStrokeColor = OverrideStrokeColor;
                 _render.CustomBrushes       = CustomBrushes;
                 _render.OverrideStrokeWidth = OverrideStrokeWidth;
                 _render.UseAnimations       = false;
@@ -298,6 +324,8 @@ namespace SVGImage.SVG
                 _render = new SVGRender();
                 _render.ExternalFileLoader  = this.ExternalFileLoader;
                 _render.OverrideColor       = OverrideColor;
+                _render.OverrideFillColor   = OverrideFillColor;
+                _render.OverrideStrokeColor = OverrideStrokeColor;
                 _render.CustomBrushes       = CustomBrushes;
                 _render.OverrideStrokeWidth = OverrideStrokeWidth;
                 _render.UseAnimations       = false;
@@ -326,6 +354,8 @@ namespace SVGImage.SVG
                 _render = new SVGRender();
                 _render.ExternalFileLoader  = this.ExternalFileLoader;
                 _render.OverrideColor       = OverrideColor;
+                _render.OverrideFillColor   = OverrideFillColor;
+                _render.OverrideStrokeColor = OverrideStrokeColor;
                 _render.CustomBrushes       = CustomBrushes;
                 _render.OverrideStrokeWidth = OverrideStrokeWidth;
                 _render.UseAnimations       = this.UseAnimations;
@@ -694,7 +724,7 @@ namespace SVGImage.SVG
                 //case "ftp":
                 case "https":
                 case "http":
-                    using (FileSvgReader reader = new FileSvgReader(this.OverrideColor))
+                    using (FileSvgReader reader = new FileSvgReader(this.OverrideColor, this.OverrideFillColor, this.OverrideStrokeColor))
                     {
                         DrawingGroup drawGroup = reader.Read(svgSource, _render);
 
@@ -729,7 +759,7 @@ namespace SVGImage.SVG
                             {
                                 using (var zipStream = new GZipStream(svgStream, CompressionMode.Decompress))
                                 {
-                                    using (FileSvgReader reader = new FileSvgReader(this.OverrideColor))
+                                    using (FileSvgReader reader = new FileSvgReader(this.OverrideColor, this.OverrideFillColor, this.OverrideStrokeColor))
                                     {
                                         DrawingGroup drawGroup = reader.Read(zipStream, _render);
 
@@ -745,7 +775,7 @@ namespace SVGImage.SVG
                         {
                             using (svgStream)
                             {
-                                using (FileSvgReader reader = new FileSvgReader(this.OverrideColor))
+                                using (FileSvgReader reader = new FileSvgReader(this.OverrideColor, this.OverrideFillColor, this.OverrideStrokeColor))
                                 {
                                     DrawingGroup drawGroup = reader.Read(svgStream, _render);
 
@@ -781,7 +811,7 @@ namespace SVGImage.SVG
                             {
                                 using (GZipStream zipStream = new GZipStream(stream, CompressionMode.Decompress))
                                 {
-                                    using (var reader = new FileSvgReader(this.OverrideColor))
+                                    using (var reader = new FileSvgReader(this.OverrideColor, this.OverrideFillColor, this.OverrideStrokeColor))
                                     {
                                         DrawingGroup drawGroup = reader.Read(zipStream, _render);
                                         if (drawGroup != null)
@@ -796,7 +826,7 @@ namespace SVGImage.SVG
                         {
                             using (var stream = new MemoryStream(imageBytes))
                             {
-                                using (var reader = new FileSvgReader(this.OverrideColor))
+                                using (var reader = new FileSvgReader(this.OverrideColor, this.OverrideFillColor, this.OverrideStrokeColor))
                                 {
                                     DrawingGroup drawGroup = reader.Read(stream, _render);
                                     if (drawGroup != null)
@@ -870,6 +900,26 @@ namespace SVGImage.SVG
             if (d is SVGImage svgImage && e.NewValue is Color newColor && svgImage._render != null)
             {
                 svgImage._render.OverrideColor = newColor;
+                svgImage.InvalidateVisual();
+                svgImage.ReRenderSvg();
+            }
+        }
+
+        private static void OverrideFillColorPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is SVGImage svgImage && e.NewValue is Color newColor && svgImage._render != null)
+            {
+                svgImage._render.OverrideFillColor = newColor;
+                svgImage.InvalidateVisual();
+                svgImage.ReRenderSvg();
+            }
+        }
+
+        private static void OverrideStrokeColorPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is SVGImage svgImage && e.NewValue is Color newColor && svgImage._render != null)
+            {
+                svgImage._render.OverrideStrokeColor = newColor;
                 svgImage.InvalidateVisual();
                 svgImage.ReRenderSvg();
             }

--- a/Source/SVGImage/SVG/SVGRender.cs
+++ b/Source/SVGImage/SVG/SVGRender.cs
@@ -35,6 +35,10 @@ namespace SVGImage.SVG
         public bool UseAnimations { get; set; }
 
         public Color? OverrideColor { get; set; }
+
+        public Color? OverrideFillColor { get; set; }
+
+        public Color? OverrideStrokeColor { get; set; }
        
         public double? OverrideStrokeWidth { get; set; }
 
@@ -125,6 +129,9 @@ namespace SVGImage.SVG
                 if (OverrideColor != null)
                     brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity), 
                         OverrideColor.Value.R, OverrideColor.Value.G, OverrideColor.Value.B));
+                if (OverrideStrokeColor != null)
+                    brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity), 
+                        OverrideStrokeColor.Value.R, OverrideStrokeColor.Value.G, OverrideStrokeColor.Value.B));
                 item.Pen = new Pen(brush, stroke.Width);
                 if (stroke.StrokeArray != null)
                 {
@@ -169,6 +176,9 @@ namespace SVGImage.SVG
                 if (OverrideColor != null)
                     item.Brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity), 
                         OverrideColor.Value.R, OverrideColor.Value.G, OverrideColor.Value.B));
+                if (OverrideFillColor != null)
+                    item.Brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity), 
+                        OverrideFillColor.Value.R, OverrideFillColor.Value.G, OverrideFillColor.Value.B));
                 GeometryGroup g = new GeometryGroup();
                 g.FillRule = FillRule.Nonzero;
                 g.Children.Add(geometry);
@@ -180,6 +190,9 @@ namespace SVGImage.SVG
                 if (OverrideColor != null)
                     item.Brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity), 
                         OverrideColor.Value.R, OverrideColor.Value.G, OverrideColor.Value.B));
+                if (OverrideFillColor != null && shape.Fill.Opacity > 0.0)
+                    item.Brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity),
+                        OverrideFillColor.Value.R, OverrideFillColor.Value.G, OverrideFillColor.Value.B));
                 GeometryGroup g = new GeometryGroup();
                 g.FillRule = FillRule.Nonzero;
                 if (shape.Fill.FillRule == Fill.eFillRule.evenodd) g.FillRule = FillRule.EvenOdd;

--- a/Source/SVGImage/SVG/SVGRender.cs
+++ b/Source/SVGImage/SVG/SVGRender.cs
@@ -121,23 +121,24 @@ namespace SVGImage.SVG
             Stroke stroke = shape.Stroke;
             if (stroke != null)
             {
-                if(OverrideStrokeWidth.HasValue)
+                var strokeWidth = stroke.Width;
+                if (OverrideStrokeWidth.HasValue)
                 {
-                    stroke.Width = OverrideStrokeWidth.Value;
+                    strokeWidth = OverrideStrokeWidth.Value;
                 }
                 var brush = stroke.StrokeBrush(this.SVG, this, shape, shape.Opacity, geometry.Bounds);
                 if (OverrideColor != null)
                     brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity), 
                         OverrideColor.Value.R, OverrideColor.Value.G, OverrideColor.Value.B));
                 if (OverrideStrokeColor != null)
-                    brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity), 
+                    brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity),
                         OverrideStrokeColor.Value.R, OverrideStrokeColor.Value.G, OverrideStrokeColor.Value.B));
-                item.Pen = new Pen(brush, stroke.Width);
+                item.Pen = new Pen(brush, strokeWidth);
                 if (stroke.StrokeArray != null)
                 {
                     item.Pen.DashCap = PenLineCap.Flat;
                     DashStyle ds = new DashStyle();
-                    double scale = 1 / stroke.Width;
+                    double scale = 1 / strokeWidth;
                     foreach (var dash in stroke.StrokeArray) ds.Dashes.Add(dash * scale);
                     item.Pen.DashStyle = ds;
                 }
@@ -177,7 +178,7 @@ namespace SVGImage.SVG
                     item.Brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity), 
                         OverrideColor.Value.R, OverrideColor.Value.G, OverrideColor.Value.B));
                 if (OverrideFillColor != null)
-                    item.Brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity), 
+                    item.Brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity),
                         OverrideFillColor.Value.R, OverrideFillColor.Value.G, OverrideFillColor.Value.B));
                 GeometryGroup g = new GeometryGroup();
                 g.FillRule = FillRule.Nonzero;
@@ -187,12 +188,15 @@ namespace SVGImage.SVG
             else if (shape.Fill != null)
             {
                 item.Brush = shape.Fill.FillBrush(this.SVG, this, shape, shape.Opacity, geometry.Bounds);
-                if (OverrideColor != null)
-                    item.Brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity), 
-                        OverrideColor.Value.R, OverrideColor.Value.G, OverrideColor.Value.B));
-                if (OverrideFillColor != null && shape.Fill.Opacity > 0.0)
-                    item.Brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity),
-                        OverrideFillColor.Value.R, OverrideFillColor.Value.G, OverrideFillColor.Value.B));
+                if (item.Brush != null)
+                {
+                    if (OverrideColor != null)
+                        item.Brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity), 
+                            OverrideColor.Value.R, OverrideColor.Value.G, OverrideColor.Value.B));
+                    if (OverrideFillColor != null)
+                        item.Brush = new SolidColorBrush(Color.FromArgb((byte)(255 * shape.Opacity),
+                            OverrideFillColor.Value.R, OverrideFillColor.Value.G, OverrideFillColor.Value.B));
+                }
                 GeometryGroup g = new GeometryGroup();
                 g.FillRule = FillRule.Nonzero;
                 if (shape.Fill.FillRule == Fill.eFillRule.evenodd) g.FillRule = FillRule.EvenOdd;

--- a/Source/SVGImage/SVG/SvgIconBase.cs
+++ b/Source/SVGImage/SVG/SvgIconBase.cs
@@ -46,6 +46,8 @@ namespace SVGImage.SVG
         #region Public Properties        
 
         public Color? OverrideColor { get; set; }
+        public Color? OverrideFillColor { get; set; }
+        public Color? OverrideStrokeColor { get; set; }
 
         /// <summary>
         /// Gets or sets the main culture information used for rendering texts.
@@ -136,7 +138,7 @@ namespace SVGImage.SVG
                 //case "ftp":
                 case "https":
                 case "http":
-                    using (FileSvgReader reader = new FileSvgReader(this.OverrideColor))
+                    using (FileSvgReader reader = new FileSvgReader(this.OverrideColor, this.OverrideFillColor, this.OverrideStrokeColor))
                     {
                         DrawingGroup drawGroup = reader.Read(svgSource);
 
@@ -171,7 +173,7 @@ namespace SVGImage.SVG
                             {
                                 using (var zipStream = new GZipStream(svgStream, CompressionMode.Decompress))
                                 {
-                                    using (FileSvgReader reader = new FileSvgReader(this.OverrideColor))
+                                    using (FileSvgReader reader = new FileSvgReader(this.OverrideColor, this.OverrideFillColor, this.OverrideStrokeColor))
                                     {
                                         DrawingGroup drawGroup = reader.Read(zipStream);
 
@@ -187,7 +189,7 @@ namespace SVGImage.SVG
                         {
                             using (svgStream)
                             {
-                                using (FileSvgReader reader = new FileSvgReader(this.OverrideColor))
+                                using (FileSvgReader reader = new FileSvgReader(this.OverrideColor, this.OverrideFillColor, this.OverrideStrokeColor))
                                 {
                                     DrawingGroup drawGroup = reader.Read(svgStream);
 
@@ -223,7 +225,7 @@ namespace SVGImage.SVG
                             {
                                 using (GZipStream zipStream = new GZipStream(stream, CompressionMode.Decompress))
                                 {
-                                    using (var reader = new FileSvgReader(this.OverrideColor))
+                                    using (var reader = new FileSvgReader(this.OverrideColor, this.OverrideFillColor, this.OverrideStrokeColor))
                                     {
                                         DrawingGroup drawGroup = reader.Read(zipStream);
                                         if (drawGroup != null)
@@ -238,7 +240,7 @@ namespace SVGImage.SVG
                         {
                             using (var stream = new MemoryStream(imageBytes))
                             {
-                                using (var reader = new FileSvgReader(this.OverrideColor))
+                                using (var reader = new FileSvgReader(this.OverrideColor, this.OverrideFillColor, this.OverrideStrokeColor))
                                 {
                                     DrawingGroup drawGroup = reader.Read(stream);
                                     if (drawGroup != null)
@@ -448,15 +450,19 @@ namespace SVGImage.SVG
 
         private CultureInfo _culture;
         private Color? _overrideColor;
+        private Color? _overrideFillColor;
+        private Color? _overrideStrokeColor;
         private bool _isDisposed;
 
         public FileSvgReader()
         {                
         }
 
-        public FileSvgReader(Color? overrideColor)
+        public FileSvgReader(Color? overrideColor, Color? overrideFillColor, Color? overrideStrokeColor)
         {
             _overrideColor = overrideColor;
+            _overrideFillColor = overrideFillColor;
+            _overrideStrokeColor = overrideStrokeColor;
         }
 
         ~FileSvgReader()
@@ -494,6 +500,26 @@ namespace SVGImage.SVG
             }
         }
 
+        public Color? OverrideFillColor 
+        { 
+            get {
+                return _overrideFillColor;
+            }
+            set {
+                _overrideFillColor = value;
+            }
+        }
+
+        public Color? OverrideStrokeColor 
+        { 
+            get {
+                return _overrideStrokeColor;
+            }
+            set {
+                _overrideStrokeColor = value;
+            }
+        }
+
         public DrawingGroup Read(string filepath, SVGRender svgRender = null)
         {
             if (string.IsNullOrWhiteSpace(filepath))
@@ -505,6 +531,8 @@ namespace SVGImage.SVG
             {
                 svgRender = new SVGRender(new FileSystemLoader());
                 svgRender.OverrideColor = _overrideColor;
+                svgRender.OverrideFillColor = _overrideFillColor;
+                svgRender.OverrideStrokeColor = _overrideStrokeColor;
             }
 
             return svgRender.LoadDrawing(filepath);
@@ -521,6 +549,8 @@ namespace SVGImage.SVG
             {
                 svgRender = new SVGRender(new FileSystemLoader());
                 svgRender.OverrideColor = _overrideColor;
+                svgRender.OverrideFillColor = _overrideFillColor;
+                svgRender.OverrideStrokeColor = _overrideStrokeColor;
             }
 
             return svgRender.LoadDrawing(fileUri);
@@ -537,6 +567,8 @@ namespace SVGImage.SVG
             {
                 svgRender = new SVGRender(new FileSystemLoader());
                 svgRender.OverrideColor = _overrideColor;
+                svgRender.OverrideFillColor = _overrideFillColor;
+                svgRender.OverrideStrokeColor = _overrideStrokeColor;
             }
 
             return svgRender.LoadDrawing(stream);

--- a/Tests/SvgTestBox/App.xaml
+++ b/Tests/SvgTestBox/App.xaml
@@ -336,5 +336,66 @@
                 </Setter.Value>
             </Setter>
         </Style>
+
+
+        <Style x:Key="ColorButton.FocusVisual">
+            <Setter Property="Control.Template">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Rectangle Margin="2" SnapsToDevicePixels="true" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" StrokeThickness="1" StrokeDashArray="1 2"/>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <SolidColorBrush x:Key="ColorButton.Static.Background" Color="#FFDDDDDD"/>
+        <SolidColorBrush x:Key="ColorButton.Static.Border" Color="#FF707070"/>
+        <SolidColorBrush x:Key="ColorButton.MouseOver.Background" Color="#FFBEE6FD"/>
+        <SolidColorBrush x:Key="ColorButton.MouseOver.Border" Color="#FF3C7FB1"/>
+        <SolidColorBrush x:Key="ColorButton.Pressed.Background" Color="#FFC4E5F6"/>
+        <SolidColorBrush x:Key="ColorButton.Pressed.Border" Color="#FF2C628B"/>
+        <SolidColorBrush x:Key="ColorButton.Disabled.Background" Color="#FFF4F4F4"/>
+        <SolidColorBrush x:Key="ColorButton.Disabled.Border" Color="#FFADB2B5"/>
+        <SolidColorBrush x:Key="ColorButton.Disabled.Foreground" Color="#FF838383"/>
+
+        <Style x:Key="btnBorderOnly" TargetType="{x:Type Button}">
+            <Setter Property="FocusVisualStyle" Value="{StaticResource ColorButton.FocusVisual}"/>
+            <Setter Property="Background" Value="#00000000"/>
+            <!--<Setter Property="BorderBrush" Value="{StaticResource ColorButton.Static.Border}"/>-->
+            <Setter Property="BorderBrush" Value="LightGray"/>
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Padding" Value="1"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                        <Border x:Name="border" CornerRadius="2" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="true">
+                            <ContentPresenter x:Name="contentPresenter" Focusable="False" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}"
+                                              RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsDefaulted" Value="true">
+                                <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}"/>
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="true">
+                                <!--<Setter Property="Background" TargetName="border" Value="{StaticResource ColorButton.MouseOver.Background}"/>-->
+                                <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource ColorButton.MouseOver.Border}"/>
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="true">
+                                <!--<Setter Property="Background" TargetName="border" Value="{StaticResource ColorButton.Pressed.Background}"/>-->
+                                <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource ColorButton.Pressed.Border}"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="false">
+                                <!--<Setter Property="Background" TargetName="border" Value="{StaticResource ColorButton.Disabled.Background}"/>-->
+                                <Setter Property="BorderBrush" TargetName="border" Value="{StaticResource ColorButton.Disabled.Border}"/>
+                                <Setter Property="TextElement.Foreground" TargetName="contentPresenter" Value="{StaticResource ColorButton.Disabled.Foreground}"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
     </Application.Resources>
 </Application>

--- a/Tests/SvgTestBox/NumericSpinner.xaml
+++ b/Tests/SvgTestBox/NumericSpinner.xaml
@@ -1,0 +1,61 @@
+﻿<UserControl x:Class="SvgTestBox.NumericSpinner"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:SvgTestBox"
+             x:Name="ctrlNumericSpinner"
+             mc:Ignorable="d" 
+             d:DesignHeight="32" d:DesignWidth="100" Padding="0">
+    <UserControl.Resources>
+        <ControlTemplate x:Key="updown_button_style" TargetType="Button">
+            <Border x:Name="br" BorderThickness="1" BorderBrush="Black" Background="Transparent" CornerRadius="0">
+                <ContentPresenter x:Name="cp" TextElement.Foreground="{TemplateBinding Foreground}" 
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+            </Border>
+            <ControlTemplate.Triggers>
+                <Trigger Property="IsMouseOver" Value="true">
+                    <Setter TargetName="br" Property="Background" Value="#FF3C7FB1" />
+                </Trigger>
+                <Trigger Property="IsEnabled" Value="false">
+                    <Setter TargetName="br" Property="Background" Value="Silver" />
+                </Trigger>
+            </ControlTemplate.Triggers>
+        </ControlTemplate>
+
+        <Style TargetType="Button">
+            <Setter Property="Template" Value="{StaticResource updown_button_style}" />
+        </Style>
+    </UserControl.Resources>
+    <Border>
+        <Border.OpacityMask>
+            <VisualBrush>
+                <VisualBrush.Visual>
+                    <Border Background="Black" SnapsToDevicePixels="True"
+                            CornerRadius="1"
+                            Width="{Binding ActualWidth, RelativeSource={RelativeSource FindAncestor, AncestorType=Border}}"
+                            Height="{Binding ActualHeight, RelativeSource={RelativeSource FindAncestor, AncestorType=Border}}" />
+                </VisualBrush.Visual>
+            </VisualBrush>
+        </Border.OpacityMask>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition />
+                <RowDefinition />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition Width="18" />
+            </Grid.ColumnDefinitions>
+            <TextBox x:Name="spinnerText" x:FieldModifier="private" HorizontalAlignment="Stretch" TextAlignment="Right" VerticalContentAlignment="Center" 
+                     Grid.Column="0" Grid.RowSpan="2" Text="0" TextChanged="OnSpinnerTextChanged" GotFocus="OnSpinnerGotFocus" />
+            <RepeatButton x:Name="spinnerUp" x:FieldModifier="private" Grid.Column="1" Grid.Row="0" Width="auto" Height="auto" Click="OnSpinnerUp">
+                <Path HorizontalAlignment="Center" VerticalAlignment="Center" Fill="Black" Data="M4,0 L0,4 L8,4 z" Stretch="UniformToFill" Margin="1"/>
+            </RepeatButton>
+            <RepeatButton x:Name="spinnerDown" x:FieldModifier="private" Grid.Column="1" Grid.Row="1" Width="auto" Height="auto" Click="OnSpinnerDown">
+                <Path HorizontalAlignment="Center" VerticalAlignment="Center" Fill="Black" Data="M0,0 L8,0 L4,4 z" Stretch="UniformToFill" Margin="1"/>
+            </RepeatButton>
+        </Grid>
+    </Border>
+</UserControl>

--- a/Tests/SvgTestBox/NumericSpinner.xaml.cs
+++ b/Tests/SvgTestBox/NumericSpinner.xaml.cs
@@ -1,0 +1,285 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace SvgTestBox
+{
+    /// <summary>
+    /// Interaction logic for NumericSpinner.xaml
+    /// </summary>
+    public partial class NumericSpinner : UserControl
+    {
+        #region Fields
+
+        public readonly static DependencyProperty ValueProperty = DependencyProperty.Register(
+            "Value",
+            typeof(decimal),
+            typeof(NumericSpinner),
+            new FrameworkPropertyMetadata(new decimal(0), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+
+        public readonly static DependencyProperty IncrementProperty = DependencyProperty.Register(
+            "Increment",
+            typeof(decimal),
+            typeof(NumericSpinner),
+            new PropertyMetadata(new decimal(0.1)));
+
+        public readonly static DependencyProperty DecimalsProperty = DependencyProperty.Register(
+            "Decimals",
+            typeof(int),
+            typeof(NumericSpinner),
+            new PropertyMetadata(2));
+
+        public readonly static DependencyProperty MinimumProperty = DependencyProperty.Register(
+            "Minimum",
+            typeof(decimal),
+            typeof(NumericSpinner),
+            new PropertyMetadata(new decimal(int.MinValue)));
+
+        public readonly static DependencyProperty MaximumProperty = DependencyProperty.Register(
+            "Maximum",
+            typeof(decimal),
+            typeof(NumericSpinner),
+            new PropertyMetadata(new decimal(int.MaxValue)));
+
+        public static readonly RoutedEvent ValueChangedEvent = EventManager.RegisterRoutedEvent(
+            "ValueChanged", RoutingStrategy.Direct, typeof(RoutedPropertyChangedEventHandler<decimal>), typeof(NumericSpinner));
+        public event RoutedPropertyChangedEventHandler<decimal> ValueChanged
+        {
+            add {
+                base.AddHandler(ValueChangedEvent, value);
+            }
+            remove {
+                base.RemoveHandler(ValueChangedEvent, value);
+            }
+        }
+
+        public static readonly RoutedEvent DoubleChangedEvent = EventManager.RegisterRoutedEvent(
+            "DoubleChanged", RoutingStrategy.Direct, typeof(RoutedPropertyChangedEventHandler<double>), typeof(NumericSpinner));
+        public event RoutedPropertyChangedEventHandler<double> DoubleChanged
+        {
+            add {
+                base.AddHandler(DoubleChangedEvent, value);
+            }
+            remove {
+                base.RemoveHandler(DoubleChangedEvent, value);
+            }
+        }
+
+        public static readonly RoutedEvent IntegerChangedEvent = EventManager.RegisterRoutedEvent(
+            "IntegerChanged", RoutingStrategy.Direct, typeof(RoutedPropertyChangedEventHandler<int>), typeof(NumericSpinner));
+        public event RoutedPropertyChangedEventHandler<int> IntegerChanged
+        {
+            add {
+                base.AddHandler(IntegerChangedEvent, value);
+            }
+            remove {
+                base.RemoveHandler(IntegerChangedEvent, value);
+            }
+        }
+
+        #endregion
+
+        private string oldText = string.Empty;
+
+        public NumericSpinner()
+        {
+            InitializeComponent();
+
+            spinnerText.SetBinding(TextBox.TextProperty, new Binding("Value")
+            {
+                ElementName = "ctrlNumericSpinner",
+                Mode = BindingMode.TwoWay,
+                UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
+            });
+
+            spinnerText.Text = this.Value.ToString();
+        }
+
+        #region Public Properties
+
+        public decimal Value
+        {
+            get { return (decimal)GetValue(ValueProperty); }
+            set {
+                if (value < Minimum)
+                    value = Minimum;
+                if (value > Maximum)
+                    value = Maximum;
+
+                var oldValue = this.Value;
+
+                value = this.CoerceValue(value, false);
+
+                if (oldValue == value)
+                {
+                    return;
+                }
+
+                SetValue(ValueProperty, value);
+
+                var newValue = value;
+
+                this.RaiseEvents(oldValue, newValue);
+            }
+        }
+
+        public double DoubleValue
+        {
+            get {
+                return Convert.ToDouble(this.Value);
+            }
+            set {
+                this.Value = Convert.ToDecimal(value);
+            }
+        }
+
+        public int IntegerValue
+        {
+            get {
+                return Convert.ToInt32(this.Value);
+            }
+            set {
+                this.Value = Convert.ToDecimal(value);
+            }
+        }
+
+        public decimal Increment
+        {
+            get { return (decimal)GetValue(IncrementProperty); }
+            set {
+                SetValue(IncrementProperty, value);
+            }
+        }
+
+        public int Decimals
+        {
+            get { return (int)GetValue(DecimalsProperty); }
+            set {
+                SetValue(DecimalsProperty, value);
+
+                this.CoerceValue(this.Value, true);
+            }
+        }
+
+        public decimal Minimum
+        {
+            get { return (decimal)GetValue(MinimumProperty); }
+            set {
+                if (value > Maximum)
+                    Maximum = value;
+                SetValue(MinimumProperty, value);
+
+                this.CoerceValue(this.Value, true);
+            }
+        }
+
+        public decimal Maximum
+        {
+            get { return (decimal)GetValue(MaximumProperty); }
+            set {
+                if (value < Minimum)
+                    value = Minimum;
+                SetValue(MaximumProperty, value);
+
+                this.CoerceValue(this.Value, true);
+            }
+        }
+
+        #endregion
+
+        protected override void OnInitialized(EventArgs e)
+        {
+            base.OnInitialized(e);
+        }
+
+        /// <summary>
+        /// Revalidate the object, whenever a value is changed...
+        /// </summary>
+        private decimal CoerceValue(decimal value, bool applyValue)
+        {
+            if (Minimum > Maximum) Minimum = Maximum;
+            if (Maximum < Minimum) Maximum = Minimum;
+            if (value < Minimum) value = Minimum;
+            if (value > Maximum) value = Maximum;
+
+            value = decimal.Round(value, Decimals);
+            if (applyValue)
+            {
+                this.Value = value;
+            }
+
+            return value;
+        }
+
+        private void OnSpinnerUp(object sender, RoutedEventArgs e)
+        {
+            this.Value += this.Increment;
+        }
+
+        private void OnSpinnerDown(object sender, RoutedEventArgs e)
+        {
+            this.Value -= this.Increment;
+        }
+
+        private void OnSpinnerGotFocus(object sender, RoutedEventArgs e)
+        {
+            oldText = spinnerText.Text.Trim();
+        }
+
+        private void OnSpinnerTextChanged(object sender, TextChangedEventArgs e)
+        {
+            var inputText = spinnerText.Text.Trim();
+
+            if (inputText.Length == 0)
+            {
+                this.Value = this.Minimum;
+            }
+            else
+            {
+                if (decimal.TryParse(inputText, out decimal newValue))
+                {
+                    newValue = CoerceValue(newValue, false);
+
+                    if (newValue != this.Value)
+                    {
+                        this.Value = newValue;
+                    }
+                    else if (string.Equals(oldText, inputText) == false)
+                    {
+                        decimal oldValue = this.Minimum;
+                        if (!string.IsNullOrWhiteSpace(oldText) && decimal.TryParse(oldText, out decimal tryValue))
+                        {
+                            oldValue = CoerceValue(tryValue, false);
+                        }
+
+                        this.RaiseEvents(oldValue, newValue);
+                    }
+                }
+            }
+        }
+
+        private void RaiseEvents(decimal oldValue, decimal newValue)
+        {
+            if (this.IsLoaded == false || oldValue == newValue)
+            {
+                return;
+            }
+
+            this.RaiseEvent(new RoutedPropertyChangedEventArgs<decimal>(oldValue, newValue, ValueChangedEvent));
+            this.RaiseEvent(new RoutedPropertyChangedEventArgs<double>(
+                Convert.ToDouble(oldValue), Convert.ToDouble(newValue), DoubleChangedEvent));
+            this.RaiseEvent(new RoutedPropertyChangedEventArgs<int>(
+                Convert.ToInt32(oldValue), Convert.ToInt32(newValue), IntegerChangedEvent));
+        }
+    }
+}

--- a/Tests/SvgTestBox/SvgPage.xaml
+++ b/Tests/SvgTestBox/SvgPage.xaml
@@ -6,6 +6,7 @@
     xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
     xmlns:svgc="https://github.com/dotnetprojects/SVGImage"
     xmlns:local="clr-namespace:SvgTestBox"
+    xmlns:sys="clr-namespace:System;assembly=mscorlib"
     mc:Ignorable="d" 
     Title="SvgPage" Background="White" d:DesignHeight="450" d:DesignWidth="800"
         DragEnter="OnDragEnter" DragLeave="OnDragLeave" Drop="OnDragDrop" AllowDrop="True"
@@ -96,20 +97,36 @@
         <local:GridExpander x:Name="rightSplitter" Grid.Row="1" Height="14" HorizontalAlignment="Stretch" VerticalAlignment="Center" 
                       BorderThickness="1" BorderBrush="LightGray" Background="LightGray"/>
         <DockPanel x:Name="viewerFrame" LastChildFill="True" Grid.Row="2">
+            <GroupBox Width="120" Header="Overridable" DockPanel.Dock="Right" FontSize="14" Margin="6">
+                <StackPanel Orientation="Vertical" DockPanel.Dock="Right">
+                    <CheckBox x:Name="chkColor" Margin="0 3 0 0" IsChecked="False" Click="OnColorChecked"  FontWeight="Bold" FontSize="12">Color</CheckBox>
+                    <Button x:Name="btnColor" Margin="24 0" Height="24" IsEnabled="False" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Transparent" />
+                    <CheckBox x:Name="chkFillColor" Margin="0 3 0 0" IsChecked="False" Click="OnFillColorChecked"  FontWeight="Bold" FontSize="12">Fill Color</CheckBox>
+                    <Button x:Name="btnFillColor" Margin="24 0" Height="24" IsEnabled="False" Click="OnFillColorClicked" Style="{StaticResource btnBorderOnly}" Background="Transparent" />
+                    <CheckBox x:Name="chkStrokeColor" Margin="0 3 0 0" IsChecked="False" Click="OnStrokeColorChecked"  FontWeight="Bold" FontSize="12">Stroke Color</CheckBox>
+                    <Button x:Name="btnStrokeColor" Margin="24 0" Height="24" IsEnabled="False" Click="OnStrokeColorClicked" Style="{StaticResource btnBorderOnly}" Background="Transparent" />
+
+                    <CheckBox x:Name="chkStrokeWidth" Margin="0 20 0 0" Click="OnStrokeWidthChecked" IsChecked="False" FontWeight="Bold" FontSize="12">Stroke Width</CheckBox>
+                    <ComboBox x:Name="cboStrokeWidth" Margin="24 0" IsEnabled="False" Height="24" SelectionChanged="OnStrokeWidthChanged">
+                        <ComboBox.Resources>
+                            <DataTemplate DataType="{x:Type sys:String}">
+                                <TextBlock x:Name="text" Text="{Binding}" />
+                            </DataTemplate>
+                        </ComboBox.Resources>
+                        <sys:String>1</sys:String>
+                        <sys:String>2</sys:String>
+                        <sys:String>3</sys:String>
+                        <sys:String>4</sys:String>
+                        <sys:String>5</sys:String>
+                        <sys:String>6</sys:String>
+                        <sys:String>7</sys:String>
+                        <sys:String>8</sys:String>
+                        <sys:String>9</sys:String>
+                    </ComboBox>
+                </StackPanel>
+            </GroupBox>
             <local:ZoomBorder x:Name="zoomBorder" ClipToBounds="True">
                 <local:ZoomBorder.Background>
-                    <!--<DrawingBrush TileMode="Tile" Viewport="-10,-10,20,20" ViewportUnits="Absolute" Opacity="0.5">
-                        <DrawingBrush.Drawing>
-                            <GeometryDrawing>
-                                <GeometryDrawing.Geometry>
-                                    <RectangleGeometry Rect="0,0,80,80"/>
-                                </GeometryDrawing.Geometry>
-                                <GeometryDrawing.Pen>
-                                    <Pen Brush="LightGray" Thickness="1"/>
-                                </GeometryDrawing.Pen>
-                            </GeometryDrawing>
-                        </DrawingBrush.Drawing>
-                    </DrawingBrush>-->
                     <DrawingBrush TileMode="Tile" Viewport="0,0,16,16" ViewportUnits="Absolute">
                         <DrawingBrush.Drawing>
                             <GeometryDrawing Geometry="M0,0 H1 V1 H2 V2 H1 V1 H0Z">

--- a/Tests/SvgTestBox/SvgPage.xaml.cs
+++ b/Tests/SvgTestBox/SvgPage.xaml.cs
@@ -60,6 +60,14 @@ namespace SvgTestBox
 
         private readonly SearchPanel _searchPanel;
 
+        private Color? _selectedColor;
+        private Color? _selectedFillColor;
+        private Color? _selectedStrokeColor;
+        private double? _overrideStrokeWidth;
+        private SvgResourceColors _colorsDlg;
+        private SvgResourceColors _colorsFillDlg;
+        private SvgResourceColors _colorsStrokeDlg;
+
         #endregion
 
         #region Constructors and Destructor
@@ -104,6 +112,8 @@ namespace SvgTestBox
 
             this.Loaded += OnPageLoaded;
             this.SizeChanged += OnPageSizeChanged;
+
+            _selectedColor = null;
         }
 
         #endregion
@@ -311,6 +321,38 @@ namespace SvgTestBox
                 {
                     _fileReader = new FileSvgReader(_xamlPage);
                 }
+                if (chkColor.IsChecked.HasValue && chkColor.IsChecked.Value)
+                {
+                    _fileReader.OverrideColor = _selectedColor;
+                }
+                else
+                {
+                    _fileReader.OverrideColor = null;
+                }
+                if (chkFillColor.IsChecked.HasValue && chkFillColor.IsChecked.Value)
+                {
+                    _fileReader.OverrideFillColor = _selectedFillColor;
+                }
+                else
+                {
+                    _fileReader.OverrideFillColor = null;
+                }
+                if (chkStrokeColor.IsChecked.HasValue && chkStrokeColor.IsChecked.Value)
+                {
+                    _fileReader.OverrideStrokeColor = _selectedStrokeColor;
+                }
+                else
+                {
+                    _fileReader.OverrideStrokeColor = null;
+                }
+                if (chkStrokeWidth.IsChecked.HasValue && chkStrokeWidth.IsChecked.Value)
+                {
+                    _fileReader.OverrideStrokeWidth = _overrideStrokeWidth;
+                }
+                else
+                {
+                    _fileReader.OverrideStrokeWidth = null;
+                }
 
                 DrawingGroup drawing = _fileReader.Read(filePath, _directoryInfo);
                 if (drawing == null)
@@ -400,6 +442,202 @@ namespace SvgTestBox
         #endregion
 
         #region Private Event Handlers
+
+        private void OnColorChecked(object sender, RoutedEventArgs e)
+        {
+            if (chkColor.IsChecked.HasValue)
+            {
+                btnColor.IsEnabled = chkColor.IsChecked.Value;
+            }
+            else
+            {
+                btnColor.IsEnabled = false;
+            }
+
+            this.OnConvertInputClick(sender, e);
+        }
+
+        private void OnColorClicked(object sender, RoutedEventArgs e)
+        {
+            _colorsDlg = new SvgResourceColors();
+            _colorsDlg.Owner = Application.Current.MainWindow;
+            if (_selectedColor != null && _selectedColor.HasValue)
+            {
+                _colorsDlg.OriginalColor = _selectedColor.Value;
+            }
+
+            _colorsDlg.Closed += OnResourceColorClosed;
+
+            _colorsDlg.Show();
+        }
+        private void OnFillColorChecked(object sender, RoutedEventArgs e)
+        {
+            if (chkFillColor.IsChecked.HasValue)
+            {
+                btnFillColor.IsEnabled = chkFillColor.IsChecked.Value;
+            }
+            else
+            {
+                btnFillColor.IsEnabled = false;
+            }
+
+            this.OnConvertInputClick(sender, e);
+        }
+
+        private void OnFillColorClicked(object sender, RoutedEventArgs e)
+        {
+            _colorsFillDlg = new SvgResourceColors();
+            _colorsFillDlg.Owner = Application.Current.MainWindow;
+            if (_selectedFillColor != null && _selectedFillColor.HasValue)
+            {
+                _colorsFillDlg.OriginalColor = _selectedFillColor.Value;
+            }
+
+            _colorsFillDlg.Closed += OnResourceFillColorClosed;
+
+            _colorsFillDlg.Show();
+        }
+        private void OnStrokeColorChecked(object sender, RoutedEventArgs e)
+        {
+            if (chkStrokeColor.IsChecked.HasValue)
+            {
+                btnStrokeColor.IsEnabled = chkStrokeColor.IsChecked.Value;
+            }
+            else
+            {
+                btnStrokeColor.IsEnabled = false;
+            }
+
+            this.OnConvertInputClick(sender, e);
+        }
+
+        private void OnStrokeColorClicked(object sender, RoutedEventArgs e)
+        {
+            _colorsStrokeDlg = new SvgResourceColors();
+            _colorsStrokeDlg.Owner = Application.Current.MainWindow;
+            if (_selectedStrokeColor != null && _selectedStrokeColor.HasValue)
+            {
+                _colorsStrokeDlg.OriginalColor = _selectedStrokeColor.Value;
+            }
+
+            _colorsStrokeDlg.Closed += OnResourceStrokeColorClosed;
+
+            _colorsStrokeDlg.Show();
+        }
+
+        private void OnStrokeWidthChecked(object sender, RoutedEventArgs e)
+        {
+            if (chkStrokeWidth.IsChecked.HasValue)
+            {
+                cboStrokeWidth.IsEnabled = chkStrokeWidth.IsChecked.Value;
+            }
+            else
+            {
+                cboStrokeWidth.IsEnabled = false;
+            }
+
+            this.OnConvertInputClick(sender, e);
+        }
+
+        private void OnStrokeWidthChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (cboStrokeWidth.SelectedIndex < 0)
+            {
+                return;
+            }
+
+            try
+            {
+                _overrideStrokeWidth = double.Parse(cboStrokeWidth.SelectedValue.ToString());
+            } 
+            catch
+            {
+                _overrideStrokeWidth = null;
+            }
+
+            this.OnConvertInputClick(sender, e);
+        }
+
+        private void OnResourceColorClosed(object sender, EventArgs e)
+        {
+            if (_colorsDlg == null)
+            {
+                return;
+            }
+            _colorsDlg.Closed -= OnResourceColorClosed;
+
+            if (_colorsDlg.DialogResult == false)
+            {
+                return;
+            }
+            _selectedColor = _colorsDlg.SelectedColor;
+            if (_selectedColor != null && _selectedColor.HasValue)
+            {
+                btnColor.Background = new SolidColorBrush(_selectedColor.Value);
+            }
+            else
+            {
+                btnColor.Background = Brushes.Transparent;
+            }
+
+            _colorsDlg = null;
+
+            this.OnConvertInputClick(sender, null);
+        }
+
+        private void OnResourceFillColorClosed(object sender, EventArgs e)
+        {
+            if (_colorsFillDlg == null)
+            {
+                return;
+            }
+            _colorsFillDlg.Closed -= OnResourceFillColorClosed;
+
+            if (_colorsFillDlg.DialogResult == false)
+            {
+                return;
+            }
+            _selectedFillColor = _colorsFillDlg.SelectedColor;
+            if (_selectedFillColor != null && _selectedFillColor.HasValue)
+            {
+                btnFillColor.Background = new SolidColorBrush(_selectedFillColor.Value);
+            }
+            else
+            {
+                btnFillColor.Background = Brushes.Transparent;
+            }
+
+            _colorsFillDlg = null;
+
+            this.OnConvertInputClick(sender, null);
+        }
+
+        private void OnResourceStrokeColorClosed(object sender, EventArgs e)
+        {
+            if (_colorsStrokeDlg == null)
+            {
+                return;
+            }
+            _colorsStrokeDlg.Closed -= OnResourceStrokeColorClosed;
+
+            if (_colorsStrokeDlg.DialogResult == false)
+            {
+                return;
+            }
+            _selectedStrokeColor = _colorsStrokeDlg.SelectedColor;
+            if (_selectedStrokeColor != null && _selectedStrokeColor.HasValue)
+            {
+                btnStrokeColor.Background = new SolidColorBrush(_selectedStrokeColor.Value);
+            }
+            else
+            {
+                btnStrokeColor.Background = Brushes.Transparent;
+            }
+
+            _colorsStrokeDlg = null;
+
+            this.OnConvertInputClick(sender, null);
+        }
 
         private void OnOpenFileClick(object sender, RoutedEventArgs e)
         {
@@ -702,6 +940,9 @@ namespace SvgTestBox
             public const string GZipSignature = "H4sI";
 
             private Color? _overrideColor;
+            private Color? _overrideFillColor;
+            private Color? _overrideStrokeColor;
+            private double? _overrideStrokeWidth;
             private bool _isDisposed;
 
             private XamlPage _xamlPage;
@@ -739,6 +980,36 @@ namespace SvgTestBox
                 }
             }
 
+            public Color? OverrideFillColor
+            {
+                get {
+                    return _overrideFillColor;
+                }
+                set {
+                    _overrideFillColor = value;
+                }
+            }
+
+            public Color? OverrideStrokeColor
+            {
+                get {
+                    return _overrideStrokeColor;
+                }
+                set {
+                    _overrideStrokeColor = value;
+                }
+            }
+
+            public double? OverrideStrokeWidth 
+            { 
+                get {
+                    return _overrideStrokeWidth;
+                }
+                set {
+                    _overrideStrokeWidth = value;
+                }
+            }
+
             public DrawingGroup Read(string filePath, DirectoryInfo workingDir)
             {
                 if (string.IsNullOrWhiteSpace(filePath))
@@ -748,6 +1019,9 @@ namespace SvgTestBox
 
                 var svgRender = new SVGRender(new FileSystemLoader());
                 svgRender.OverrideColor = _overrideColor;
+                svgRender.OverrideFillColor = _overrideFillColor;
+                svgRender.OverrideStrokeColor = _overrideStrokeColor;
+                svgRender.OverrideStrokeWidth = _overrideStrokeWidth;
                 svgRender.UseAnimations = true;
 
                 var drawingGroup = svgRender.LoadDrawing(filePath);

--- a/Tests/SvgTestBox/SvgResourceColors.xaml
+++ b/Tests/SvgTestBox/SvgResourceColors.xaml
@@ -1,0 +1,301 @@
+﻿<Window x:Class="SvgTestBox.SvgResourceColors"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:SvgTestBox"
+        mc:Ignorable="d"
+        Title="Pick a Color" Height="400" Width="490" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" ShowInTaskbar="False">
+    <Window.Resources>
+        <Style x:Key="Item.FocusVisual">
+            <Setter Property="Control.Template">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Rectangle Margin="2" SnapsToDevicePixels="true" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" StrokeThickness="1" StrokeDashArray="1 2"/>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <SolidColorBrush x:Key="Item.Static.Background" Color="#FFFCFCFC" />
+        <SolidColorBrush x:Key="Item.Static.Border" Color="#FFFCFCFC" />
+        <SolidColorBrush x:Key="Item.MouseOver.Background" Color="#1F26A0DA" />
+        <SolidColorBrush x:Key="Item.MouseOver.Border" Color="#a826A0Da" />
+        <SolidColorBrush x:Key="Item.SelectedActive.Background" Color="#3D26A0DA" />
+        <SolidColorBrush x:Key="Item.SelectedActive.Border" Color="#FF26A0DA" />
+        <SolidColorBrush x:Key="Item.SelectedInactive.Background" Color="#3DDADADA" />
+        <SolidColorBrush x:Key="Item.SelectedInactive.Border" Color="#FFDADADA" />
+        <Style x:Key="StretchedContainerStyle" TargetType="{x:Type ListBoxItem}">
+            <Setter Property="SnapsToDevicePixels" Value="True" />
+            <Setter Property="Padding" Value="1,1" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="FocusVisualStyle" Value="{StaticResource Item.FocusVisual}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                        <Border x:Name="Bd" 
+                        BorderBrush="{TemplateBinding BorderBrush}" 
+                        BorderThickness="{TemplateBinding BorderThickness}" 
+                        Background="{TemplateBinding Background}" 
+                        Padding="{TemplateBinding Padding}" 
+                        SnapsToDevicePixels="true">
+                            <ContentPresenter 
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsMouseOver" Value="True" />
+                                </MultiTrigger.Conditions>
+                                <Setter TargetName="Bd" Property="Background" Value="{StaticResource Item.MouseOver.Background}" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource Item.MouseOver.Border}" />
+                            </MultiTrigger>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="Selector.IsSelectionActive" Value="False" />
+                                    <Condition Property="IsSelected" Value="True" />
+                                </MultiTrigger.Conditions>
+                                <Setter TargetName="Bd" Property="Background" Value="{StaticResource Item.SelectedActive.Background}" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource Item.SelectedActive.Border}" />
+                            </MultiTrigger>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="Selector.IsSelectionActive" Value="True" />
+                                    <Condition Property="IsSelected" Value="True" />
+                                </MultiTrigger.Conditions>
+                                <Setter TargetName="Bd" Property="Background" Value="{StaticResource Item.SelectedActive.Background}" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="{StaticResource Item.SelectedActive.Border}" />
+                            </MultiTrigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Bd" Property="TextElement.Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
+    <StackPanel Orientation="Vertical" x:Name="grid" Margin="12" VerticalAlignment="Top">
+        <StackPanel Orientation="Horizontal" >
+            <StackPanel Orientation="Vertical" Width="24">
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LightSteelBlue" ToolTip="Light Steel Blue"/>
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="BlueViolet" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="MediumPurple" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="MediumSlateBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="SlateBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="SteelBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="MidnightBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkSlateBlue" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Width="24">
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Lavender" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Thistle" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Plum" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Violet" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Orchid" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="MediumOrchid" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkViolet" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkOrchid" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkMagenta" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Purple" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Indigo" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Width="24">
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="MistyRose" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LightCoral" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LightSalmon" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Salmon" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkSalmon" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="RosyBrown" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="IndianRed" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Red" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Crimson" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Firebrick" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkRed" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Maroon" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Brown" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Width="24">
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LavenderBlush" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="SeaShell" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Linen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Pink" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LightPink" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="HotPink" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DeepPink" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Fuchsia" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Magenta" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="MediumVioletRed" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="PaleVioletRed" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Width="24">
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="FloralWhite" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="PapayaWhip" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Moccasin" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="PeachPuff" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="NavajoWhite" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkOrange" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Orange" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Coral" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Tomato" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="OrangeRed" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Width="24">
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Ivory" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LightYellow" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LightGoldenrodYellow" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LemonChiffon" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="PaleGoldenrod" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Khaki" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Yellow" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Gold" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkKhaki" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Goldenrod" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkGoldenrod" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Olive" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Width="24">
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="MintCream" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="GreenYellow" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Chartreuse" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LawnGreen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Lime" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LimeGreen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="YellowGreen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="OliveDrab" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="ForestGreen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Green" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkOliveGreen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkGreen" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Width="24">
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="PaleGreen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="SpringGreen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LightGreen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="MediumSpringGreen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="MediumAquamarine" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkSeaGreen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LightSeaGreen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="CadetBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="MediumSeaGreen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="SeaGreen" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkCyan" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Teal" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkSlateGray" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Width="24">
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="AliceBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LightBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="SkyBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LightSkyBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Turquoise" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="MediumTurquoise" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkTurquoise" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DodgerBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="CornflowerBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="RoyalBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Blue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="MediumBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Navy" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Width="24">
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Azure" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Honeydew" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LightCyan" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Aqua" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Cyan" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Aquamarine" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="PaleTurquoise" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="PowderBlue" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DeepSkyBlue" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Width="24">
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Cornsilk" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Beige" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="OldLace" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="AntiqueWhite" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="BlanchedAlmond" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Bisque" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Wheat" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Tan" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="BurlyWood" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="SandyBrown" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Peru" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Chocolate" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Sienna" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="SaddleBrown" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical" Width="24">
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="White" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Snow" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="GhostWhite" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="WhiteSmoke" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Gainsboro" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LightGray" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Silver" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DarkGray" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="LightSlateGray" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="SlateGray" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Gray" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="DimGray" />
+                <Button Height="20" Margin="1" Click="OnColorClicked" Style="{StaticResource btnBorderOnly}" Background="Black" />
+            </StackPanel>
+
+            <StackPanel Orientation="Vertical" Margin="12 0 0 0">
+                <GroupBox>
+                    <GroupBox.Header>
+                        <TextBlock Text="Selected Color" FontWeight="Bold"/>
+                    </GroupBox.Header>
+                    <StackPanel Orientation="Vertical" Margin="6,3,3,6">
+                        <Border x:Name="brdrOrgColor" BorderBrush="LightGray" BorderThickness="1 1 1 1" Height="40"/>
+                        <Border x:Name="brdrSelColor" BorderBrush="LightGray" BorderThickness="1 0 1 1" Height="40"/>
+                        <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                            <!-- Hex -->
+                            <TextBlock x:Name="lblHex" Text="Hex" VerticalAlignment="Center" Margin="0 0 3 0" />
+                            <TextBox x:Name="txtHex" Height="24" Text="#000000" VerticalContentAlignment="Center" Width="90" MaxLength="9" TextChanged="OnHexTextChanged" />
+                            <TextBlock x:Name="lblQ" Text="s" Foreground="Red" FontFamily="Webdings" FontSize="16" VerticalAlignment="Center" Visibility="Hidden" />
+                        </StackPanel>
+                    </StackPanel>
+                </GroupBox>
+
+                <GroupBox>
+                    <GroupBox.Header>
+                        <TextBlock x:Name="lblAlpha" Text="ARGB" FontWeight="Bold"/>
+                    </GroupBox.Header>
+                    <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" Margin="6,0,6,0">
+                        <DockPanel>
+                            <!-- A -->
+                            <TextBlock x:Name="lblA" DockPanel.Dock="Left" HorizontalAlignment="Left" Text="A" VerticalAlignment="Center"/>
+                            <local:NumericSpinner x:Name="nudAlpha" DockPanel.Dock="Right" HorizontalAlignment="Right" Height="24" VerticalAlignment="Center" Width="80" Value="0" Minimum="0" Increment="1" Maximum="255" IntegerChanged="OnAlphaChanged" />
+                        </DockPanel>
+                        <DockPanel>
+                            <!-- R -->
+                            <TextBlock x:Name="lblR" DockPanel.Dock="Left" HorizontalAlignment="Left" Text="R" VerticalAlignment="Center"/>
+                            <local:NumericSpinner x:Name="nudR" DockPanel.Dock="Right" HorizontalAlignment="Right" Height="24" VerticalAlignment="Center" Width="80" Value="0" Minimum="0" Maximum="255" Increment="1" IntegerChanged="OnRgbChanged" />
+                        </DockPanel>
+                        <DockPanel>
+                            <!-- G -->
+                            <TextBlock x:Name="lblG" DockPanel.Dock="Left" HorizontalAlignment="Left" Text="G" VerticalAlignment="Center"/>
+                            <local:NumericSpinner x:Name="nudG" DockPanel.Dock="Right" HorizontalAlignment="Right" Height="24" VerticalAlignment="Center" Width="80" Value="0" Minimum="0" Maximum="255" Increment="1" IntegerChanged="OnRgbChanged" />
+                        </DockPanel>
+                        <DockPanel>
+                            <!-- B -->
+                            <TextBlock x:Name="lblB" DockPanel.Dock="Left" HorizontalAlignment="Left" Text="B" VerticalAlignment="Center"/>
+                            <local:NumericSpinner x:Name="nudB" DockPanel.Dock="Right" HorizontalAlignment="Right" Height="24" VerticalAlignment="Center" Width="80" Value="0" Minimum="0" Maximum="255" Increment="1" IntegerChanged="OnRgbChanged" />
+                        </DockPanel>
+                    </StackPanel>
+                </GroupBox>
+            </StackPanel>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="12">
+            <Button x:Name="btnOK" Click="OnApplyClicked" Margin="6,0,6,0" Content="OK" VerticalAlignment="Center" Height="24" Width="120" />
+            <Button x:Name="btnCancel" Click="OnCancelClicked" Margin="6,0,6,0" Content="Cancel" VerticalAlignment="Center" Height="24" Width="120" />
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/Tests/SvgTestBox/SvgResourceColors.xaml.cs
+++ b/Tests/SvgTestBox/SvgResourceColors.xaml.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.ComponentModel;
+
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace SvgTestBox
+{
+    /// <summary>
+    /// Interaction logic for SvgResourceColors.xaml
+    /// </summary>
+    public partial class SvgResourceColors : Window
+    {
+        private enum UpdateValueType
+        {
+            None,
+            Rgb,
+            Hsv,
+            Hex,
+            Alpha,
+            All
+        }
+
+        private bool _isUpdating;
+        private Color _brdrOrgColor;
+
+        #region Constructors
+        public SvgResourceColors()
+        {
+            InitializeComponent();
+
+            this.OriginalColor = Colors.Transparent;
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// Gets or sets the color selected in this dialog.
+        /// </summary>
+        public Color SelectedColor { get; private set; } = Colors.Transparent;
+
+        /// <summary>
+        /// Gets the dialog result of this dialog, based upon whether the user accepted the changes.
+        /// </summary>
+        public new bool DialogResult { get; private set; } = false;
+
+        public Color OriginalColor
+        {
+            get {
+                return _brdrOrgColor;
+            }
+            set {
+                _brdrOrgColor = value;
+
+                brdrOrgColor.Background = new SolidColorBrush(value);
+            }
+        }
+
+        #endregion
+
+        private void UpdateSelectedColor(Color color, bool includeSliders = true)
+        {
+            this.SelectedColor = color;
+            brdrSelColor.Background = new SolidColorBrush(color);
+
+            if (_brdrOrgColor == Colors.Transparent)
+            {
+                this.OriginalColor = color;
+            }
+
+            if (includeSliders)
+            {
+                UpdateValues(color, UpdateValueType.None);
+            }
+        }
+
+        #region Private Event Handlers
+
+        private void OnColorClicked(object sender, RoutedEventArgs e)
+        {
+            UpdateSelectedColor(((sender as Button).Background as System.Windows.Media.SolidColorBrush).Color);
+        }
+
+        private void OnRValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (!_isUpdating)
+            {
+                nudR.Value = (int)e.NewValue;
+            }
+        }
+
+        private void OnGValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (!_isUpdating)
+            {
+                nudG.Value = (int)e.NewValue;
+            }
+        }
+
+        private void OnBValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (!_isUpdating)
+            {
+                nudB.Value = (int)e.NewValue;
+            }
+        }
+
+        private void OnHexTextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (this.IsLoaded == false)
+            {
+                return;
+            }
+            try
+            {
+                Color col = (Color)ColorConverter.ConvertFromString(txtHex.Text);
+                lblQ.Visibility = Visibility.Hidden;
+
+                UpdateValues(col, UpdateValueType.Hex);
+            }
+            catch (Exception)
+            {
+                lblQ.Visibility = Visibility.Visible;
+            }
+        }
+
+        private void OnAlphaChanged(object sender, RoutedPropertyChangedEventArgs<int> e)
+        {
+            if (this.IsLoaded == false || _isUpdating)
+            {
+                return;
+            }
+
+            Color col = Color.FromArgb((byte)nudAlpha.IntegerValue, (byte)nudR.IntegerValue, (byte)nudG.IntegerValue, (byte)nudB.IntegerValue);
+            UpdateValues(col, UpdateValueType.Alpha);
+        }
+
+        private void OnRgbChanged(object sender, RoutedPropertyChangedEventArgs<int> e)
+        {
+            if (this.IsLoaded == false || _isUpdating)
+            {
+                return;
+            }
+
+            Color col = Color.FromArgb((byte)nudAlpha.IntegerValue, (byte)nudR.IntegerValue, (byte)nudG.IntegerValue, (byte)nudB.IntegerValue);
+            UpdateValues(col, UpdateValueType.Rgb);
+        }
+
+        private void OnApplyClicked(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void OnCancelClicked(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+
+        #endregion
+
+        #region Color Conversion Functions
+
+        private void UpdateValues(Color color, UpdateValueType except)
+        {
+            if (except == UpdateValueType.All)
+            {
+                return;
+            }
+
+            _isUpdating = true;
+
+            if (except != UpdateValueType.Rgb)
+            {
+                nudR.Value = color.R;
+                nudG.Value = color.G;
+                nudB.Value = color.B;
+            }
+
+            if (except != UpdateValueType.Hex)
+            {
+                txtHex.Text = color.ToString();
+            }
+
+            if (except != UpdateValueType.Alpha)
+            {
+                nudAlpha.IntegerValue = color.A;
+            }
+
+            UpdateSelectedColor(color, false);
+
+            _isUpdating = false;
+        }
+
+        #endregion
+    }
+
+}


### PR DESCRIPTION
## Description

Right now, both the fill and stroke colors can be overridden through the `OverrideColor` property in SVGImage. Allowing to override both a fill and a stroke color independently would allow a user to set a stroke color different from a fill color. The two proposed properties, `OverrideFillColor` and `OverrideStrokeColor` are also consistent to the `OverrideStrokeWidth` property that has already been implemented.
Implementing this would also allow users to (partially) work around bug #84 .
By adding two new properties while keeping the current `OverrideColor` property intact, we maintain compatibility and do not introduce any breaking changes.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] .NET Framework, Version 4.0
- [x] .NET Framework, Version 4.5
- [x] .NET Framework, Version 4.6
- [x] .NET Framework, Version 4.7
- [x] .NET Framework, Version 4.8
- [x] .NET Core, Version 3.1
- [x] .NET 6 ~ 8
- [x] All Included Samples

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
