### PR TITLE
Bug fixes and code improvements

### DIFF
--- a/Docs/index.md
+++ b/Docs/index.md
@@ -15,13 +15,13 @@ The respository includes
 * **Samples:** For sample applications
 * **Docs:** For the documentations (in markdown format).
 
-The command lines installation options are: For the version `5.1.0`
-* **.NET CLI:** dotnet add package DotNetProjects.SVGImage --version 5.1.0
-* **Package Manager:** NuGet\Install-Package DotNetProjects.SVGImage -Version 5.1.0
+The command lines installation options are: For the version `5.1.1`
+* **.NET CLI:** dotnet add package DotNetProjects.SVGImage --version 5.1.1
+* **Package Manager:** NuGet\Install-Package DotNetProjects.SVGImage -Version 5.1.1
 
-For reference in projects use: For the version `5.1.0`
+For reference in projects use: For the version `5.1.1`
 ```xml
-<PackageReference Include="DotNetProjects.SVGImage" Version="5.1.0" />
+<PackageReference Include="DotNetProjects.SVGImage" Version="5.1.1" />
 ```
 
 ## How to build

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,1 +1,1 @@
-next-version: 5.1.0
+next-version: 5.1.1

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ The respository includes
 * **Samples:** For sample applications
 * **Docs:** For the documentations (in markdown format).
 
-The command lines installation options are: For the version `5.1.0`
-* **.NET CLI:** dotnet add package DotNetProjects.SVGImage --version 5.1.0
-* **Package Manager:** NuGet\Install-Package DotNetProjects.SVGImage -Version 5.1.0
+The command lines installation options are: For the version `5.1.1`
+* **.NET CLI:** dotnet add package DotNetProjects.SVGImage --version 5.1.1
+* **Package Manager:** NuGet\Install-Package DotNetProjects.SVGImage -Version 5.1.1
 
-For reference in projects use: For the version `5.1.0`
+For reference in projects use: For the version `5.1.1`
 ```xml
-<PackageReference Include="DotNetProjects.SVGImage" Version="5.1.0" />
+<PackageReference Include="DotNetProjects.SVGImage" Version="5.1.1" />
 ```
 
 ## How to build

--- a/Samples/ClipArtViewer/ClipArtViewer.csproj
+++ b/Samples/ClipArtViewer/ClipArtViewer.csproj
@@ -30,6 +30,17 @@
   <PropertyGroup>
     <ApplicationIcon>ClipArtViewer.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net40' ">$(DefineConstants);DOTNET40;NETFULL</DefineConstants>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('net45'))">$(DefineConstants);DOTNET45;NETFULL</DefineConstants>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('net46'))">$(DefineConstants);DOTNET46;NETFULL</DefineConstants>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('net47'))">$(DefineConstants);DOTNET47;NETFULL</DefineConstants>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('net48'))">$(DefineConstants);DOTNET48;NETFULL</DefineConstants>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('netcore'))">$(DefineConstants);NETCORE</DefineConstants>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('net6'))">$(DefineConstants);NETCORE;NETNEXT</DefineConstants>
+	<DefineConstants Condition="$(TargetFramework.StartsWith('net7'))">$(DefineConstants);NETCORE;NETNEXT</DefineConstants>
+	<DefineConstants Condition="$(TargetFramework.StartsWith('net8'))">$(DefineConstants);NETCORE;NETNEXT</DefineConstants>
+  </PropertyGroup>	
   <ItemGroup>
     <ProjectReference Include="..\..\Source\SVGImage\DotNetProjects.SVGImage.csproj" />
   </ItemGroup>

--- a/Samples/ClipArtViewer/Properties/AssemblyInfo.cs
+++ b/Samples/ClipArtViewer/Properties/AssemblyInfo.cs
@@ -4,6 +4,10 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 
+#if NETNEXT
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows7.0")]
+#endif
+
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.

--- a/Samples/CustomBrushesExample/CustomBrushesExample.csproj
+++ b/Samples/CustomBrushesExample/CustomBrushesExample.csproj
@@ -25,6 +25,17 @@
   <PropertyGroup>
     <ApplicationIcon>CustomBrushesExample.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net40' ">$(DefineConstants);DOTNET40;NETFULL</DefineConstants>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('net45'))">$(DefineConstants);DOTNET45;NETFULL</DefineConstants>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('net46'))">$(DefineConstants);DOTNET46;NETFULL</DefineConstants>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('net47'))">$(DefineConstants);DOTNET47;NETFULL</DefineConstants>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('net48'))">$(DefineConstants);DOTNET48;NETFULL</DefineConstants>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('netcore'))">$(DefineConstants);NETCORE</DefineConstants>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('net6'))">$(DefineConstants);NETCORE;NETNEXT</DefineConstants>
+	<DefineConstants Condition="$(TargetFramework.StartsWith('net7'))">$(DefineConstants);NETCORE;NETNEXT</DefineConstants>
+	<DefineConstants Condition="$(TargetFramework.StartsWith('net8'))">$(DefineConstants);NETCORE;NETNEXT</DefineConstants>
+  </PropertyGroup>	
   <ItemGroup>
     <ProjectReference Include="..\..\Source\SVGImage\DotNetProjects.SVGImage.csproj" />
   </ItemGroup>

--- a/Samples/CustomBrushesExample/Properties/AssemblyInfo.cs
+++ b/Samples/CustomBrushesExample/Properties/AssemblyInfo.cs
@@ -4,6 +4,10 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 
+#if NETNEXT
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows7.0")]
+#endif
+
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.

--- a/Samples/Example/Properties/AssemblyInfo.cs
+++ b/Samples/Example/Properties/AssemblyInfo.cs
@@ -4,6 +4,10 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 
+#if NETNEXT
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows7.0")]
+#endif
+
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.

--- a/Samples/IconConverterSample/Properties/AssemblyInfo.cs
+++ b/Samples/IconConverterSample/Properties/AssemblyInfo.cs
@@ -4,6 +4,10 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 
+#if NETNEXT
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows7.0")]
+#endif
+
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.

--- a/Source/SVGImage/DotNetProjects.SVGImage.csproj
+++ b/Source/SVGImage/DotNetProjects.SVGImage.csproj
@@ -11,9 +11,9 @@
 		<Product>DotNetProjects.SVGImage</Product>
 		<Copyright>2020-2023 DotNetProjects</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<AssemblyVersion>5.1.0.0</AssemblyVersion>
-		<FileVersion>5.1.0.0</FileVersion>
-		<Version>5.1.0</Version>
+		<AssemblyVersion>5.1.1.0</AssemblyVersion>
+		<FileVersion>5.1.1.0</FileVersion>
+		<Version>5.1.1</Version>
 		<OutputType>Library</OutputType>
 		<Configurations>Debug;Release</Configurations>
 	</PropertyGroup>
@@ -31,7 +31,7 @@
 		<PackageReadmeFile>Readme.md</PackageReadmeFile>
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<!-- NOTE: Detect breaking changes from a previous version -->
-		<PackageValidationBaselineVersion>5.0.118</PackageValidationBaselineVersion>
+		<PackageValidationBaselineVersion>5.1.0</PackageValidationBaselineVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Source/SVGImage/Properties/AssemblyInfo.cs
+++ b/Source/SVGImage/Properties/AssemblyInfo.cs
@@ -2,6 +2,10 @@
 using System.Windows;
 using System.Windows.Markup;
 
+#if NETNEXT
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows7.0")]
+#endif
+
 //In order to begin building localizable applications, set 
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english

--- a/Source/SVGImage/SVG/Fill.cs
+++ b/Source/SVGImage/SVG/Fill.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System.Diagnostics;
+using System.Windows;
 using System.Windows.Media;
 
 namespace SVGImage.SVG
@@ -14,16 +15,66 @@ namespace SVGImage.SVG
             evenodd
         }
 
-        public eFillRule FillRule { get; set;}
+        private SVG _svg;
 
-        public string PaintServerKey {get; set;}
+        private bool _isDefault;
 
-        public double Opacity {get; set;}
+        private eFillRule _fillRule;
+
+        private string _paintServerKey;
+
+        private double _opacity;
 
         public Fill(SVG svg)
         {
-            this.FillRule = eFillRule.nonzero;
-            this.Opacity = 100;
+            _fillRule = eFillRule.nonzero;
+            _opacity = 100;
+            _isDefault = false;
+            _svg = svg;
+        }
+
+        public static Fill CreateDefault(SVG svg, string fillColor)
+        {
+            var fill = new Fill(svg);
+            fill.PaintServerKey = svg.PaintServers.Parse(fillColor);
+
+            fill._isDefault = true;
+
+            return fill;
+        }
+
+        public SVG get => _svg;
+
+        public bool IsDefault
+        {
+            get => _isDefault;
+            set => _isDefault = value;
+        }
+
+        public eFillRule FillRule { 
+            get => _fillRule;
+            set {
+                Debug.Assert(_isDefault == false);
+                _fillRule = value;
+            }
+        }
+
+        public string PaintServerKey 
+        {
+            get => _paintServerKey; 
+            set {
+                Debug.Assert(_isDefault == false);
+                _paintServerKey = value;
+            }
+        }
+
+        public double Opacity 
+        {
+            get => _opacity;
+            set {
+                Debug.Assert(_isDefault == false);
+                _opacity = value;
+            }
         }
 
         public bool IsEmpty(SVG svg)

--- a/Source/SVGImage/SVG/PaintServers/PaintServerManager.cs
+++ b/Source/SVGImage/SVG/PaintServers/PaintServerManager.cs
@@ -244,7 +244,8 @@ namespace SVGImage.SVG.PaintServers
 
         private static void LoadKnownColors()
         {
-            if (m_knownColors == null) m_knownColors = new Dictionary<string, Color>();
+            if (m_knownColors == null) 
+                m_knownColors = new Dictionary<string, Color>(StringComparer.OrdinalIgnoreCase);
             if (m_knownColors.Count == 0)
             {
                 PropertyInfo[] propinfos = typeof(Colors).GetProperties(BindingFlags.Public | BindingFlags.Static);

--- a/Source/SVGImage/SVG/Shapes/CircleShape.cs
+++ b/Source/SVGImage/SVG/Shapes/CircleShape.cs
@@ -8,8 +8,15 @@ namespace SVGImage.SVG.Shapes
 
     public sealed class CircleShape : Shape
     {
+        private static Fill DefaultFill = null;
+
         public CircleShape(SVG svg, XmlNode node) : base(svg, node)
         {
+            if (DefaultFill == null)
+            {
+                DefaultFill = Fill.CreateDefault(svg, "black");
+            }
+
             Rect? box = svg.ViewBox;
 
             this.CX = XmlUtil.AttrValue(node, "cx", 0, box.HasValue ? box.Value.Width : svg.Size.Width);
@@ -19,6 +26,15 @@ namespace SVGImage.SVG.Shapes
             if (box.HasValue)
                 diagRef = Math.Sqrt(box.Value.Width * box.Value.Width + box.Value.Height * box.Value.Height) / Math.Sqrt(2);
             this.R = XmlUtil.AttrValue(node, "r", 0, diagRef);
+        }
+
+        public override Fill Fill
+        {
+            get {
+                Fill f = base.Fill;
+                if (f == null) f = DefaultFill;
+                return f;
+            }
         }
 
         public double CX { get; set; }

--- a/Source/SVGImage/SVG/Shapes/EllipseShape.cs
+++ b/Source/SVGImage/SVG/Shapes/EllipseShape.cs
@@ -8,9 +8,16 @@ namespace SVGImage.SVG.Shapes
 
     public sealed class EllipseShape : Shape
     {
+        private static Fill DefaultFill = null;
+
         public EllipseShape(SVG svg, XmlNode node)
             : base(svg, node)
         {
+            if (DefaultFill == null)
+            {
+                DefaultFill = Fill.CreateDefault(svg, "black");
+            }
+
             Rect? box = svg.ViewBox;
 
             this.CX = XmlUtil.AttrValue(node, "cx", 0, box.HasValue ? box.Value.Width : svg.Size.Width);
@@ -21,6 +28,15 @@ namespace SVGImage.SVG.Shapes
                     + box.Value.Height * box.Value.Height) / Math.Sqrt(2);
             this.RX = XmlUtil.AttrValue(node, "rx", 0, diagRef);
             this.RY = XmlUtil.AttrValue(node, "ry", 0, diagRef);
+        }
+
+        public override Fill Fill
+        {
+            get {
+                Fill f = base.Fill;
+                if (f == null) f = DefaultFill;
+                return f;
+            }
         }
 
         public double CX { get; set; }

--- a/Source/SVGImage/SVG/Shapes/PathShape.cs
+++ b/Source/SVGImage/SVG/Shapes/PathShape.cs
@@ -14,8 +14,7 @@ namespace SVGImage.SVG
         {
             if (DefaultFill == null)
             {
-                DefaultFill = new Fill(svg);
-                DefaultFill.PaintServerKey = svg.PaintServers.Parse("black");
+                DefaultFill = Fill.CreateDefault(svg, "black");
             }
 
             this.ClosePath = false;

--- a/Source/SVGImage/SVG/Shapes/PolygonShape.cs
+++ b/Source/SVGImage/SVG/Shapes/PolygonShape.cs
@@ -15,8 +15,7 @@ namespace SVGImage.SVG.Shapes
         {
             if (DefaultFill == null)
             {
-                DefaultFill = new Fill(svg);
-                DefaultFill.PaintServerKey = svg.PaintServers.Parse("black");
+                DefaultFill = Fill.CreateDefault(svg, "black");
             }
 
             string points = XmlUtil.AttrValue(node, SVGTags.sPoints, string.Empty);

--- a/Source/SVGImage/SVG/Shapes/RectangleShape.cs
+++ b/Source/SVGImage/SVG/Shapes/RectangleShape.cs
@@ -12,8 +12,7 @@ namespace SVGImage.SVG.Shapes
         {
             if (DefaultFill == null)
             {
-                DefaultFill = new Fill(svg);
-                DefaultFill.PaintServerKey = svg.PaintServers.Parse("black");
+                DefaultFill = Fill.CreateDefault(svg, "black");
             }
         }
 

--- a/Source/SVGImage/SVG/Shapes/Text.cs
+++ b/Source/SVGImage/SVG/Shapes/Text.cs
@@ -9,32 +9,9 @@ namespace SVGImage.SVG
 
     public sealed class TextShape : Shape
     {
-        public double X { get; set; }
-        public double Y { get; set; }
-        public string Text { get; set; }
-        public TextSpan TextSpan {get; private set;}
-        static Fill DefaultFill = null;
-        static Stroke DefaultStroke = null;
-        public override Fill Fill 
-        { 
-            get 
-            {
-                Fill f = base.Fill;
-                if (f == null)
-                    f = DefaultFill;
-                return f;
-            }
-        }
-        public override Stroke Stroke
-        { 
-            get 
-            {
-                Stroke f = base.Stroke;
-                if (f == null)
-                    f = DefaultStroke;
-                return f;
-            }
-        }
+        private static Fill DefaultFill = null;
+        private static Stroke DefaultStroke = null;
+
         public TextShape(SVG svg, XmlNode node, Shape parent) 
             : base(svg, node, parent)
         {
@@ -47,13 +24,38 @@ namespace SVGImage.SVG
                 this.TextSpan = this.ParseTSpan(svg, node.InnerXml);
             if (DefaultFill == null)
             {
-                DefaultFill = new Fill(svg);
-                DefaultFill.PaintServerKey = svg.PaintServers.Parse("black");
+                DefaultFill = Fill.CreateDefault(svg, "black");
             }
             if (DefaultStroke == null)
             {
-                DefaultStroke = new Stroke(svg);
-                DefaultStroke.Width = 0.1;
+                DefaultStroke = Stroke.CreateDefault(svg, 0.1);
+            }
+        }
+
+        public double X { get; set; }
+        public double Y { get; set; }
+        public string Text { get; set; }
+        public TextSpan TextSpan {get; private set;}
+
+        public override Fill Fill 
+        { 
+            get 
+            {
+                Fill f = base.Fill;
+                if (f == null)
+                    f = DefaultFill;
+                return f;
+            }
+        }
+
+        public override Stroke Stroke
+        { 
+            get 
+            {
+                Stroke f = base.Stroke;
+                if (f == null)
+                    f = DefaultStroke;
+                return f;
             }
         }
 

--- a/Source/SVGImage/SVG/Stroke.cs
+++ b/Source/SVGImage/SVG/Stroke.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System.Diagnostics;
+using System.Windows;
 using System.Windows.Media;
 
 namespace SVGImage.SVG
@@ -22,24 +23,102 @@ namespace SVGImage.SVG
             bevel,
         }
 
-        public string PaintServerKey { get; set; }
+        private SVG _svg;
 
-        public double Width { get; set; }
+        private bool _isDefault;
 
-        public double Opacity { get; set; }
+        private string _paintServerKey;
 
-        public eLineCap LineCap { get; set; }
+        private double _opacity;
 
-        public eLineJoin LineJoin { get; set; }
+        private double _width;
 
-        public double[] StrokeArray { get; set; }
+        private eLineCap _lineCap;
+
+        private eLineJoin _lineJoin;
+
+        private double[] _strokeArray;
 
         public Stroke(SVG svg)
         {
-            this.Width = 1;
-            this.LineCap = eLineCap.butt;
-            this.LineJoin = eLineJoin.miter;
-            this.Opacity = 100;
+            _svg = svg;
+            _isDefault = false;
+            _width = 1;
+            _lineCap = eLineCap.butt;
+            _lineJoin = eLineJoin.miter;
+            _opacity = 100;
+        }
+
+        public static Stroke CreateDefault(SVG svg, double width)
+        {
+            var stroke = new Stroke(svg);
+            stroke._width = width;
+
+            stroke._isDefault = true;
+
+            return stroke;
+        }
+
+        public SVG get => _svg;
+
+        public bool IsDefault
+        {
+            get => _isDefault;
+            set => _isDefault = value;
+        }
+
+        public string PaintServerKey
+        {
+            get => _paintServerKey;
+            set {
+                Debug.Assert(_isDefault == false);
+                _paintServerKey = value;
+            }
+        }
+
+        public double Opacity
+        {
+            get => _opacity;
+            set {
+                Debug.Assert(_isDefault == false);
+                _opacity = value;
+            }
+        }
+
+        public double Width
+        {
+            get => _width;
+            set {
+                Debug.Assert(_isDefault == false);
+                _width = value;
+            }
+        }
+
+        public eLineCap LineCap
+        {
+            get => _lineCap;
+            set {
+                Debug.Assert(_isDefault == false);
+                _lineCap = value;
+            }
+        }
+
+        public eLineJoin LineJoin
+        {
+            get => _lineJoin;
+            set {
+                Debug.Assert(_isDefault == false);
+                _lineJoin = value;
+            }
+        }
+
+        public double[] StrokeArray
+        {
+            get => _strokeArray;
+            set {
+                Debug.Assert(_isDefault == false);
+                _strokeArray = value;
+            }
         }
 
         public bool IsEmpty(SVG svg)

--- a/Tests/SvgTestBox/Properties/AssemblyInfo.cs
+++ b/Tests/SvgTestBox/Properties/AssemblyInfo.cs
@@ -4,6 +4,10 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 
+#if NETNEXT
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows7.0")]
+#endif
+
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.

--- a/Tests/SvgTestSuites/Properties/AssemblyInfo.cs
+++ b/Tests/SvgTestSuites/Properties/AssemblyInfo.cs
@@ -4,6 +4,10 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 
+#if NETNEXT
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows7.0")]
+#endif
+
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.


### PR DESCRIPTION
## Description

- Removed the private `ControlLine` class (no longer used as path is parsed with WPF parser)
- Add `IsDefault` property to Fill and Stroke to make default fills and strokes known
- Eliminated the 135, warning CA1416: This call site is reachable on all platforms.
- Eliminated some "as" casts, with the new "is" syntax.

Fixes and Closes #89

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change does not require a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] .NET Framework, Version 4.0
- [x] .NET Framework, Version 4.5
- [x] .NET Framework, Version 4.6
- [x] .NET Framework, Version 4.7
- [x] .NET Framework, Version 4.8
- [x] .NET Core, Version 3.1
- [x] .NET 6 ~ 8
- [x] All Included Samples

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
