### PR TITLE
Fixed missing Null check causing NullPointerExceptions when an SVG image is placed inside a DataGridCheckBoxColumn

### DIFF
--- a/Source/SVGImage/SVG/SVGImage.cs
+++ b/Source/SVGImage/SVG/SVGImage.cs
@@ -872,7 +872,7 @@ namespace SVGImage.SVG
 
         static void OnSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            var sourceUri = new Uri(e.NewValue.ToString(), UriKind.Relative);
+            var sourceUri = e.NewValue != null ? new Uri(e.NewValue.ToString(), UriKind.Relative) : null;
             var resource = e.NewValue != null ? Application.GetResourceStream(sourceUri) : null;
             ((SVGImage)d).SetImage(resource != null ? resource.Stream : null);
         }


### PR DESCRIPTION

# Pull Request Template

## Description

This fixes a missing Null check when setting the image source

Fixes #94 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] .NET Framework, Version 4.0
- [x] .NET Framework, Version 4.5
- [x] .NET Framework, Version 4.6
- [x] .NET Framework, Version 4.7
- [x] .NET Framework, Version 4.8
- [x] .NET Core, Version 3.1
- [x] .NET 6 ~ 8
- [x] All Included Samples

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
