### PR TITLE
Access to Bounds of m_drawing

### DIFF
--- a/Source/SVGImage/SVG/SVGImage.cs
+++ b/Source/SVGImage/SVG/SVGImage.cs
@@ -163,6 +163,12 @@ namespace SVGImage.SVG
             set { this.SetValue(ImageSourcePoperty, value); }
         }
 
+        public Rect Bounds
+        {
+            get { return m_drawing.Bounds; }
+            set { }
+        }
+
         public bool UseAnimations
         {
             get { return (bool)GetValue(UseAnimationsProperty); }


### PR DESCRIPTION
Access to Bounds of m_drawing for calculation of ratio for parent control. There is also ImageSource.Bounds but it contains null.