### PR TITLE
Fix TypeInitializationException when system has duplicate font names

### DIFF
--- a/Source/SVGImage/SVG/Utils/FontResolver.cs
+++ b/Source/SVGImage/SVG/Utils/FontResolver.cs
@@ -27,8 +27,8 @@ namespace SVGImage.SVG.Utils
         public FontResolver(int maxLevenshteinDistance = 0)
         {
             _availableFonts = Fonts.SystemFontFamilies
-                .Select(ff => new { NormalName = ff.Source, Family = ff })
-                .ToDictionary(x => x.NormalName, x => x.Family, StringComparer.OrdinalIgnoreCase);
+                .GroupBy(ff => ff.Source, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
 
             _normalizedFontNameMap = new Dictionary<string, string>(_availableFonts.Count);
             foreach (var font in _availableFonts.Keys)
@@ -157,7 +157,7 @@ namespace SVGImage.SVG.Utils
                 return string.Empty;
             }
             return _normalizationRegex.Replace(fontName, String.Empty).ToLowerInvariant();
-            
+
         }
 
         private static int[,] CreateDistanceMatrix(int length1, int length2)
@@ -201,7 +201,7 @@ namespace SVGImage.SVG.Utils
                 return string1.Length;
             }
 
-            
+
             int[,] distanceMatrix = CreateDistanceMatrix(string1.Length, string2.Length);
 
             for (int i = 1; i <= string1.Length; i++)
@@ -221,5 +221,5 @@ namespace SVGImage.SVG.Utils
         }
 
     }
-    
+
 }


### PR DESCRIPTION
## Description

- Fix `TypeInitializationException` / `ArgumentException` in `FontResolver` when the system has duplicate font names (e.g. "bundaysans")
- Replace `ToDictionary` with `GroupBy` + `ToDictionary` to gracefully handle duplicates by keeping the first occurrence

## Problem

On systems where `Fonts.SystemFontFamilies` returns multiple font families with the same name (case-insensitive), the `FontResolver` constructor crashes with an `ArgumentException: An item with the same key has already been added`.

Since `FontResolver` is used in the static constructor of `TextStyle`, this causes a `TypeInitializationException` that prevents any SVG with text elements from rendering:

```
  System.TypeInitializationException: The type initializer for 'SVGImage.SVG.TextStyle' threw an exception.
   ---> System.ArgumentException: An item with the same key has already been added. Key: bundaysans
     at System.Linq.Enumerable.ToDictionary[...]
     at SVGImage.SVG.Utils.FontResolver..ctor(Int32 maxLevenshteinDistance)
     at SVGImage.SVG.TextStyle..cctor()
```

## Solution

Replaced the direct `ToDictionary` call with `GroupBy` + `ToDictionary`, which groups fonts by name first and then picks the first entry per group. This avoids the duplicate key exception while keeping the original lookup behavior intact.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] .NET Framework, Version 4.0
- [x] .NET Framework, Version 4.5
- [x] .NET Framework, Version 4.6
- [x] .NET Framework, Version 4.7
- [x] .NET Framework, Version 4.8
- [x] .NET Core, Version 3.1
- [x] .NET 6 ~ 8
- [x] All Included Samples

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
